### PR TITLE
Kill constructors

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,8 +3,6 @@ name: Test & Release
 on:
   push:
     branches: '**'
-  pull_request:
-    branches: [ "master" ]
 
 jobs:
   Test:
@@ -38,7 +36,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.merge_commit_sha }}
         fetch-depth: '0'
 
     - name: Set up Go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Test & Release
+name: Go CI
 
 on:
   push:

--- a/pkg/vec/vec2.go
+++ b/pkg/vec/vec2.go
@@ -12,28 +12,20 @@ type Vec2 struct {
 	X, Y float64
 }
 
-// NewVec2 returns a new 2D vector.
-func NewVec2(x, y float64) Vec2 {
-	return Vec2{
-		X: x,
-		Y: y,
-	}
-}
-
 // Add computes v1 + v2.
 func (v1 Vec2) Add(v2 Vec2) Vec2 {
-	return NewVec2(
-		v1.X+v2.X,
-		v1.Y+v2.Y,
-	)
+	return Vec2{
+		v1.X + v2.X,
+		v1.Y + v2.Y,
+	}
 }
 
 // Subtract computes v1 - v2.
 func (v1 Vec2) Subtract(v2 Vec2) Vec2 {
-	return NewVec2(
-		v1.X-v2.X,
-		v1.Y-v2.Y,
-	)
+	return Vec2{
+		v1.X - v2.X,
+		v1.Y - v2.Y,
+	}
 }
 
 // Dot computes the dot product between v1 and v2.
@@ -43,10 +35,10 @@ func (v1 Vec2) Dot(v2 Vec2) float64 {
 
 // Multiply returns this vector multiplied by a scalar value.
 func (v Vec2) Multiply(n float64) Vec2 {
-	return NewVec2(
-		v.X*n,
-		v.Y*n,
-	)
+	return Vec2{
+		v.X * n,
+		v.Y * n,
+	}
 }
 
 // Divide returns this vector divided by a scalar value.
@@ -55,10 +47,10 @@ func (v Vec2) Divide(n float64) (Vec2, error) {
 		return Vec2{}, errors.New("tried to divide by 0")
 	}
 
-	return NewVec2(
-		v.X/n,
-		v.Y/n,
-	), nil
+	return Vec2{
+		v.X / n,
+		v.Y / n,
+	}, nil
 }
 
 // Magnitude returns the length of this vector.
@@ -76,10 +68,10 @@ func (v Vec2) Normalised() (Vec2, error) {
 		return Vec2{}, errors.New("tried to normalise a 0-length vector")
 	}
 
-	return NewVec2(
-		v.X/magnitude,
-		v.Y/magnitude,
-	), nil
+	return Vec2{
+		v.X / magnitude,
+		v.Y / magnitude,
+	}, nil
 }
 
 // Angle computes the angle between v1 and v2, in radians.
@@ -109,10 +101,10 @@ func (v1 Vec2) Angle(v2 Vec2) (float64, error) {
 //
 // If you wish to have the result clamped between v1 and v2, use [LerpClamped].
 func (v1 Vec2) Lerp(v2 Vec2, t float64) Vec2 {
-	return NewVec2(
-		v1.X+t*(v2.X-v1.X),
-		v1.Y+t*(v2.Y-v1.Y),
-	)
+	return Vec2{
+		v1.X + t*(v2.X-v1.X),
+		v1.Y + t*(v2.Y-v1.Y),
+	}
 }
 
 // LerpClamped linearly interpolates between v1 and v2 by factor t, clamping the result between v1 and v2.

--- a/pkg/vec/vec2_test.go
+++ b/pkg/vec/vec2_test.go
@@ -5,41 +5,6 @@ import (
 	"testing"
 )
 
-func TestNewVec2(t *testing.T) {
-	tests := []struct {
-		name string
-		x    float64
-		y    float64
-		want Vec2
-	}{
-		{
-			name: "(0,0)",
-			x:    0,
-			y:    0,
-			want: Vec2{0, 0},
-		},
-		{
-			name: "(1,2)",
-			x:    1,
-			y:    2,
-			want: Vec2{1, 2},
-		},
-		{
-			name: "(3.0134,-4.2162)",
-			x:    3.0134,
-			y:    -4.2162,
-			want: Vec2{3.0134, -4.2162},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := NewVec2(tt.x, tt.y); !got.Equals(tt.want) {
-				t.Errorf("NewVec2() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestVec2_Add(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/vec/vec3.go
+++ b/pkg/vec/vec3.go
@@ -12,31 +12,22 @@ type Vec3 struct {
 	X, Y, Z float64
 }
 
-// NewVec3 returns a new 3D vector.
-func NewVec3(x, y, z float64) Vec3 {
-	return Vec3{
-		X: x,
-		Y: y,
-		Z: z,
-	}
-}
-
 // Add computes v1 + v2.
 func (v1 Vec3) Add(v2 Vec3) Vec3 {
-	return NewVec3(
-		v1.X+v2.X,
-		v1.Y+v2.Y,
-		v1.Z+v2.Z,
-	)
+	return Vec3{
+		v1.X + v2.X,
+		v1.Y + v2.Y,
+		v1.Z + v2.Z,
+	}
 }
 
 // Subtract computes v1 - v2.
 func (v1 Vec3) Subtract(v2 Vec3) Vec3 {
-	return NewVec3(
-		v1.X-v2.X,
-		v1.Y-v2.Y,
-		v1.Z-v2.Z,
-	)
+	return Vec3{
+		v1.X - v2.X,
+		v1.Y - v2.Y,
+		v1.Z - v2.Z,
+	}
 }
 
 // Dot computes the dot product between v1 and v2.
@@ -46,20 +37,20 @@ func (v1 Vec3) Dot(v2 Vec3) float64 {
 
 // Multiply returns this vector multiplied by a scalar value.
 func (v Vec3) Multiply(n float64) Vec3 {
-	return NewVec3(
-		v.X*n,
-		v.Y*n,
-		v.Z*n,
-	)
+	return Vec3{
+		v.X * n,
+		v.Y * n,
+		v.Z * n,
+	}
 }
 
 // Divide returns this vector divided by a scalar value.
 func (v Vec3) Divide(n float64) Vec3 {
-	return NewVec3(
-		v.X/n,
-		v.Y/n,
-		v.Z/n,
-	)
+	return Vec3{
+		v.X / n,
+		v.Y / n,
+		v.Z / n,
+	}
 }
 
 // Magnitude returns the length of this vector.
@@ -77,11 +68,11 @@ func (v Vec3) Normalised() (Vec3, error) {
 		return Vec3{}, errors.New("tried to normalise a 0-length vector")
 	}
 
-	return NewVec3(
-		v.X/magnitude,
-		v.Y/magnitude,
-		v.Z/magnitude,
-	), nil
+	return Vec3{
+		v.X / magnitude,
+		v.Y / magnitude,
+		v.Z / magnitude,
+	}, nil
 }
 
 // Angle computes the angle between v1 and v2, in radians.
@@ -111,11 +102,11 @@ func (v1 Vec3) Angle(v2 Vec3) (float64, error) {
 //
 // If you wish to have the result clamped between v1 and v2, use [LerpClamped].
 func (v1 Vec3) Lerp(v2 Vec3, t float64) Vec3 {
-	return NewVec3(
-		v1.X+t*(v2.X-v1.X),
-		v1.Y+t*(v2.Y-v1.Y),
-		v1.Z+t*(v2.Z-v1.Z),
-	)
+	return Vec3{
+		v1.X + t*(v2.X-v1.X),
+		v1.Y + t*(v2.Y-v1.Y),
+		v1.Z + t*(v2.Z-v1.Z),
+	}
 }
 
 // LerpClamped linearly interpolates between v1 and v2 by factor t, clamping the result between v1 and v2.
@@ -141,11 +132,11 @@ func (v1 Vec3) LerpClamped(v2 Vec3, t float64) Vec3 {
 
 // Cross returns the cross product of v1 and v2.
 func (v1 Vec3) Cross(v2 Vec3) Vec3 {
-	return NewVec3(
-		v1.Y*v2.Z-v1.Z*v2.Y,
-		v1.Z*v2.X-v1.X*v2.Z,
-		v1.X*v2.Y-v1.Y*v2.X,
-	)
+	return Vec3{
+		v1.Y*v2.Z - v1.Z*v2.Y,
+		v1.Z*v2.X - v1.X*v2.Z,
+		v1.X*v2.Y - v1.Y*v2.X,
+	}
 }
 
 // Equals returns true if the two vectors are equal.


### PR DESCRIPTION
Turns out constructors are discouraged in Go when you don't explicitly need them. Since the zero-value of a vector is useful, we're safeguarding nothing by providing a constructor.

#minor